### PR TITLE
Fix privilege escalation in profile update

### DIFF
--- a/api/src/routes/user.js
+++ b/api/src/routes/user.js
@@ -256,8 +256,14 @@ router.put('/profile',
         return res.status(404).json({ error: 'User not found' });
       }
 
-      // Update user profile in database
-      const updatedUser = await User.update(userId, req.body);
+      // Update user profile in database - only self-service profile fields.
+      // role / permissions / organizationId / isActive must never be set here;
+      // they have dedicated admin endpoints.
+      const PROFILE_FIELDS = ['firstName', 'lastName', 'phone', 'organization',
+        'department', 'jobTitle', 'location', 'bio', 'profilePicture', 'preferences'];
+      const patch = {};
+      for (const k of PROFILE_FIELDS) if (k in req.body) patch[k] = req.body[k];
+      const updatedUser = await User.update(userId, patch);
       
       if (!updatedUser) {
         return res.status(500).json({ error: 'Failed to update profile' });

--- a/api/src/services/models.js
+++ b/api/src/services/models.js
@@ -57,8 +57,8 @@ const UserModel = {
     // Whitelist of allowed fields to prevent SQL injection
     const allowedFields = [
       'username', 'email', 'firstName', 'lastName', 'phone', 'organization',
-      'department', 'jobTitle', 'location', 'bio', 'profilePicture', 
-      'preferences', 'isActive', 'organizationId', 'role', 'permissions'
+      'department', 'jobTitle', 'location', 'bio', 'profilePicture',
+      'preferences'
     ];
     
     const fields = [];


### PR DESCRIPTION
## What

`PUT /api/user/profile` passed the whole request body into `User.update`, and `User.update`'s field whitelist still included `role`, `organizationId`, `isActive` and `permissions`. Any logged-in user could set `role: "super_admin"` on their own account in a single request, then sail through every `requireSuperAdmin()` / `requirePermission('canManageAllUsers')` check.

With self-registration on, that's an unauthenticated path to full super_admin over the whole tenant set.

## Fix

- Build an explicit allowlist of profile fields at the route (`firstName`, `lastName`, `phone`, `bio`, etc.) instead of passing `req.body` straight through.
- Drop `role`, `organizationId`, `isActive` and `permissions` from `User.update`'s whitelist so they can't be set via the self-service path even if a caller tries. Role and permission changes already have dedicated admin endpoints.

## Repro (before)

```http
PUT /api/user/profile HTTP/1.1
Authorization: Bearer <any valid JWT>
Content-Type: application/json

{"role":"super_admin","permissions":{"canManageAllUsers":true}}
```

The caller's own row becomes `role = super_admin`. After this PR the same request has no effect on role.

## Notes

- Two files, no behavior change for legitimate profile edits.
- I didn't run the test suite locally - worth a quick pass on the profile-update tests before merge.
