### PR TITLE
Stop PowerShell command injection in the extractor sidecar

### DIFF
--- a/services/extractor-sidecar/src/index.js
+++ b/services/extractor-sidecar/src/index.js
@@ -31,6 +31,16 @@ async function getDefaultCertificatePassword() {
 }
 
 /**
+ * Wrap a value as a safe PowerShell single-quoted string literal. Inside a
+ * single-quoted PowerShell string the only special character is ' itself, and
+ * it is escaped by doubling it. This is what makes an interpolated value safe
+ * to embed in a command built with spawn('pwsh', ['-Command', ...]).
+ */
+function psQuote(value) {
+  return "'" + String(value ?? '').replace(/'/g, "''") + "'";
+}
+
+/**
  * Build PowerShell command for Tier 3 Exchange-only extractions.
  */
 function buildPowerShellCommand(type, parameters, credentials, orgOutputPath) {
@@ -45,23 +55,23 @@ function buildPowerShellCommand(type, parameters, credentials, orgOutputPath) {
     const certPassword = credentials.certPassword;
 
     authCommand = `
-      $securePwd = ConvertTo-SecureString '${certPassword}' -AsPlainText -Force;
+      $securePwd = ConvertTo-SecureString ${psQuote(certPassword)} -AsPlainText -Force;
       $cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2(
-        '${certPath}',
+        ${psQuote(certPath)},
         $securePwd,
         [System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
       );
-      Connect-M365 -AppId '${credentials.applicationId}' -Organization '${parameters.fqdn || parameters.organization}' -Certificate $cert -ErrorAction Stop;
-      Connect-MgGraph -ApplicationId '${credentials.applicationId}' -Certificate $cert -TenantId '${parameters.tenantId}' -ErrorAction Stop;
+      Connect-M365 -AppId ${psQuote(credentials.applicationId)} -Organization ${psQuote(parameters.fqdn || parameters.organization)} -Certificate $cert -ErrorAction Stop;
+      Connect-MgGraph -ApplicationId ${psQuote(credentials.applicationId)} -Certificate $cert -TenantId ${psQuote(parameters.tenantId)} -ErrorAction Stop;
     `;
   }
 
   const extractionCommands = {
-    'unified_audit_log': `Get-UAL -StartDate '${parameters.startDate}' -EndDate '${parameters.endDate}' -Output JSON -MergeOutput -OutputDir '${orgOutputPath}'`,
-    'admin_audit_log': `Get-AdminAuditLog -StartDate '${parameters.startDate}' -EndDate '${parameters.endDate}' -Output JSON -MergeOutput -OutputDir '${orgOutputPath}'`,
-    'mailbox_audit': `Get-MailboxAuditLog -StartDate '${parameters.startDate}' -EndDate '${parameters.endDate}' -Output JSON -MergeOutput -OutputDir '${orgOutputPath}'`,
-    'transport_rules': `Get-TransportRules -OutputDir '${orgOutputPath}'`,
-    'message_trace': `Get-MessageTraceLog -StartDate '${parameters.startDate}' -EndDate '${parameters.endDate}' -OutputDir '${orgOutputPath}'`
+    'unified_audit_log': `Get-UAL -StartDate ${psQuote(parameters.startDate)} -EndDate ${psQuote(parameters.endDate)} -Output JSON -MergeOutput -OutputDir ${psQuote(orgOutputPath)}`,
+    'admin_audit_log': `Get-AdminAuditLog -StartDate ${psQuote(parameters.startDate)} -EndDate ${psQuote(parameters.endDate)} -Output JSON -MergeOutput -OutputDir ${psQuote(orgOutputPath)}`,
+    'mailbox_audit': `Get-MailboxAuditLog -StartDate ${psQuote(parameters.startDate)} -EndDate ${psQuote(parameters.endDate)} -Output JSON -MergeOutput -OutputDir ${psQuote(orgOutputPath)}`,
+    'transport_rules': `Get-TransportRules -OutputDir ${psQuote(orgOutputPath)}`,
+    'message_trace': `Get-MessageTraceLog -StartDate ${psQuote(parameters.startDate)} -EndDate ${psQuote(parameters.endDate)} -OutputDir ${psQuote(orgOutputPath)}`
   };
 
   const extractionCmd = extractionCommands[type];


### PR DESCRIPTION
## What

The extractor sidecar runs a built command via `spawn('pwsh', ['-Command', cmd])`, and that `cmd` was assembled by dropping values straight into single-quoted PowerShell literals:

- `parameters.fqdn` / `parameters.organization`
- `parameters.tenantId`
- `parameters.startDate` / `parameters.endDate`
- `orgOutputPath`
- `credentials.applicationId`, the cert path, and the cert password

A single `'` in any of them ends the literal and the rest of the value runs as PowerShell. The `parameters.*` values come from the extraction request body (only a few sub-fields are validated; the rest pass through and then override the org defaults in `jobService`), so an analyst who can create an extraction can inject commands -> RCE on the sidecar container, and a clean SSRF to `http://169.254.169.254/...` for cloud credentials.

## Fix

Add a small `psQuote()` helper that wraps a value as a safe single-quoted PowerShell string (the only special character inside one is `'`, escaped by doubling it) and route every interpolated value through it. One file, no behavior change for legitimate values.

## Repro (before)

```http
POST /api/extractions
Authorization: Bearer <analyst JWT>
Content-Type: application/json

{
  "type": "unified_audit_log",
  "startDate": "2026-01-01T00:00:00Z",
  "endDate": "2026-01-02T00:00:00Z",
  "parameters": { "startDate": "2026-01-01'; Invoke-RestMethod http://169.254.169.254/ -UseBasicParsing; '" }
}
```

The injected `Invoke-RestMethod` runs on the sidecar. After this PR the `'` is doubled and the value stays a literal.

## Notes

- Minimal, safe-by-construction escaping. The nicer long-term fix is to pass these as `-ArgumentList` / a base64 `-EncodedCommand` and stop building a command string at all - happy to do that as a follow-up.
- The main extractor (`services/extractor/src/index.js`) has the same `buildPowerShellCommand` pattern, but no user-selectable extraction type routes there today, so it isn't the live sink. Worth hardening the same way; left out here to keep the PR focused.
- Didn't run the test suite locally.
